### PR TITLE
Port filter from ember data and deprecate

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@
 
 ### Configuration
 
+To use, you will need to add this mixin to the store. If you are
+also using another addon which extends the store, you will want
+to ensure that this mixin is applied to the store provided by
+that addon.
+
 ```js
 //  app/services/store.js
 import Store from 'ember-data/store';
@@ -83,3 +88,5 @@ License
 ------------------------------------------------------------------------------
 
 This project is licensed under the [MIT License](LICENSE.md).
+
+Copyright (c) 2015-2018

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ember Data Filter
+# [DEPRECATED] Ember Data Filter
 
 ## Install
 
@@ -6,60 +6,33 @@
 
 `ember install ember-data-filter`
 
-### Rails and Globals Mode apps
-
-You'll need to load a custom script that enables the script **before you
-load Ember**. For example, if you call your file config.js:
+### Configuration
 
 ```js
-// /config.js
+//  app/services/store.js
+import Store from 'ember-data/store';
+import FilterMixin from 'ember-data-filter/mixins/filter';
 
-window.EmberENV = window.EmberENV || {};
-window.EmberENV.ENABLE_DS_FILTER = true;
+export default Store.extend(FilterMixin);
 ```
 
-If you're using Rails, you can use a Sprockets require directive to load
-this before ember:
+## Deprecation Guide
 
-```
-// app/assets/application.js
-//= require jquery
-//= require config
-//= require ember
-// .. the rest of your require / file here ..
-```
+### ember-data-filter:filter
 
-If you're loading ember using script tags, then you can simply load
-config.js first:
-
-```html
-<script src="jquery.js"></script>
-<script src="config.js"></script>
-<script src-"ember.js"></script>
-```
-
-
-This addon enables the `Ember.EmberENV.ENABLE_DS_FILTER` flag. This
-allows you to use `store.filter` without getting a deprecation warning
-in Ember Data 1.13 and 2.0.
-
-## Why?
-
-The Filter API is about to under-go some heavy churn to fix issues with
-it.
-
-## I Don't Want to Enable this Feature Due to Its Heavy Churn
-
-You can combine `store.peekAll` in a computed property:
+You can combine `store.peekAll` with a computed property, for instance:
 
 ```js
-// app/controllers/posts.js
+// app/services/post-service.js
+import Ember from 'ember';
 
-export default Ember.Controller.extend({
-
-  posts: Ember.computed(function() {
-    return this.store.peekAll('post');
-  }),
+export default Ember.Service.extend({
+  store: inject.service('store'),
+  
+  init() {
+    this._super();
+    this.posts = this.get('store').peekAll('post');
+  },
 
   filteredPosts: Ember.computed('posts.@each.isPublished', function() {
     return this.get('posts').filterBy('isPublished');
@@ -67,46 +40,44 @@ export default Ember.Controller.extend({
 });
 ```
 
-## Development Installation
+### ember-data-filter:query-for-filter
 
+To resolve this deprecation you will want to separate your usage
+of `filter` from your usage of `query`.
 
+Replace
+
+```js
+return store.filter(modelName, query, filter, options);
 ```
-ember install my-addon
+
+with the following if you need to wait for the query
+
+```js
+return store.query(modelName, query, options)
+  .then(() => {
+    return store.filter(modelName, filter);
+  });
 ```
 
+or the below if you do not need to wait for the query
 
-Usage
-------------------------------------------------------------------------------
+```js
+store.query(modelName, query, options);
+return store.filter(modelName, filter);
+```
 
-[Longer description of how to use the addon in apps.]
+### ember-data-filter:empty-filter
 
+Replace `store.filter(modelName)` with `store.peekAll(modelName)`.
 
-Contributing
-------------------------------------------------------------------------------
+The only difference between these two is the `filter` returns a promisfied `RecordArray`
+while `peekAll` returns a `RecordArray`. If during the transition you need to
+preserve the promise behavior, you may do the below:
 
-### Installation
-
-* `git clone <repository-url>`
-* `cd my-addon`
-* `npm install`
-
-### Linting
-
-* `npm run lint:js`
-* `npm run lint:js -- --fix`
-
-### Running tests
-
-* `ember test` – Runs the test suite on the current Ember version
-* `ember test --server` – Runs the test suite in "watch mode"
-* `ember try:each` – Runs the test suite against multiple Ember versions
-
-### Running the dummy application
-
-* `ember serve`
-* Visit the dummy application at [http://localhost:4200](http://localhost:4200).
-
-For more information on using ember-cli, visit [https://ember-cli.com/](https://ember-cli.com/).
+```js
+return RSVP.Promise.resolve(store.peekAll(modelName));
+```
 
 License
 ------------------------------------------------------------------------------

--- a/addon/mixins/filter.js
+++ b/addon/mixins/filter.js
@@ -1,0 +1,192 @@
+import { computed } from '@ember/object';
+import Mixin from '@ember/object/mixin';
+import PromiseProxyMixin from '@ember/object/promise-proxy-mixin';
+import ArrayProxy from '@ember/array/proxy';
+import { assert, deprecate } from '@ember/debug';
+import { Promise } from 'rsvp';
+import DS from 'ember-data';
+
+const PromiseArray = ArrayProxy.extend(PromiseProxyMixin);
+
+export const FilteredRecordArray = ArrayProxy.extend({
+  replace() {
+    throw new Error('The result of a client-side filter (on recordType) is immutable.');
+  },
+
+  content: computed('all.[]', 'filterFunction', function() {
+    let all = this.get('all');
+    let filter = this.get('filterFunction');
+    let allRecords = all ? all.toArray() : [];
+
+    return allRecords.filter((record) => {
+      return record !== null && filter(record);
+    });
+  }),
+});
+
+/*
+  Necessary because LiveRecordArrays do not produce change notifications
+  for updates to items, only if an item is added or removed are we notified.
+
+  However, the `updateLiveRecordArray` method is called for internal updates
+  as well, so by hooking this we can ensure we are subscribed.
+ */
+const originalUpdateLiveRecordArray = DS.RecordArrayManager.prototype.updateLiveRecordArray;
+DS.RecordArrayManager.prototype.updateLiveRecordArray = function updateLiveRecordArray(recordArray, internalModels) {
+  let didUpdate = originalUpdateLiveRecordArray.call(this, recordArray, internalModels);
+
+  if (!didUpdate) {
+    this.store._notifyFilteredRecordArrays(recordArray.modelName);
+  }
+
+  return didUpdate;
+};
+
+export default Mixin.create({
+  init() {
+    this._super();
+    this._filteredRecordArrayCache = new Map();
+  },
+
+  willDestroy() {
+    this._super(...arguments);
+    this._filteredRecordArrayCache.forEach(recordArrays => {
+      recordArrays.forEach(arr => arr.destroy());
+    });
+  },
+
+  _notifyFilteredRecordArrays(modelName) {
+    let recordArrays = this._filteredRecordArraysFor(modelName);
+
+    for (let i = 0; i < recordArrays.length; i++) {
+      let arr = recordArrays[i];
+      arr.notifyPropertyChange('all');
+    }
+  },
+
+  _filteredRecordArraysFor(modelName) {
+    let map = this._filteredRecordArrayCache;
+    let arrays = map.get(modelName);
+
+    if (!arrays) {
+      arrays = [];
+      map.set(modelName, arrays);
+    }
+
+    return arrays;
+  },
+
+  /**
+   Takes a type and filter function, and returns a live RecordArray that
+   remains up to date as new records are loaded into the store or created
+   locally.
+
+   The filter function takes a materialized record, and returns true
+   if the record should be included in the filter and false if it should
+   not.
+
+   Example
+
+   ```javascript
+   store.filter('post', function(post) {
+      return post.get('unread');
+    });
+   ```
+
+   The filter function is called once on all records for the type when
+   it is created, and then once on each newly loaded or created record.
+
+   If any of a record's properties change, or if it changes state, the
+   filter function will be invoked again to determine whether it should
+   still be in the array.
+
+   Optionally you can pass a query, which is the equivalent of calling
+   [query](#method_query) with that same query, to fetch additional records
+   from the server. The results returned by the server could then appear
+   in the filter if they match the filter function.
+
+   The query itself is not used to filter records, it's only sent to your
+   server for you to be able to do server-side filtering. The filter
+   function will be applied on the returned results regardless.
+
+   Example
+
+   ```javascript
+   store.filter('post', { unread: true }, function(post) {
+      return post.get('unread');
+    }).then(function(unreadPosts) {
+      unreadPosts.get('length'); // 5
+      let unreadPost = unreadPosts.objectAt(0);
+      unreadPost.set('unread', false);
+      unreadPosts.get('length'); // 4
+    });
+   ```
+
+   @method filter
+   @private
+   @param {String} modelName
+   @param {Object} query optional query
+   @param {Function} filter
+   @param {Object} options optional, options to be passed to store.query
+   @return {PromiseArray}
+   @deprecated
+   */
+  filter(modelName, query, filter, options) {
+    assert(`You need to pass a model name to the store's filter method`, modelName);
+    assert(`Passing classes to store methods has been removed. Please pass a dasherized string instead of ${modelName}`, typeof modelName === 'string');
+
+    deprecate(
+      `store.filter has been deprecated in favor of computed properties that watch record arrays.`,
+      typeof filter === 'string',
+      {
+        id: 'ember-data-filter:filter',
+        until: '3.5',
+        url: 'https://github.com/ember-data/ember-data-filter#ember-data-filter:filter'
+      });
+
+    let promise;
+    let length = arguments.length;
+    let hasQuery = length >= 3;
+
+    // allow an optional server query
+    if (hasQuery) {
+      deprecate(`passing a query to ember-data-filter's filter method has been deprecated`, false, {
+        id: 'ember-data-filter:query-for-filter',
+        until: '3.5',
+        url: 'https://github.com/ember-data/ember-data-filter#ember-data-filter:query-for-filter'
+      });
+      promise = this.query(modelName, query, options);
+    } else if (arguments.length === 2) {
+      filter = query;
+    } else {
+      filter = () => true;
+    }
+
+    deprecate(
+      `No filter was provided in a call to store.filter(${modelName}). To filter to all of a type, use store.peekAll`,
+      filter !== '',
+      {
+        id: 'ember-data-filter:empty-filter',
+        until: '3.5',
+        url: 'https://github.com/ember-data/ember-data-filter#ember-data-filter:empty-filter'
+      });
+
+    let all = this.peekAll(modelName);
+    let normalizedModelName = all.modelName;
+    let array = FilteredRecordArray.create({
+      query,
+      modelName: normalizedModelName,
+      all,
+      filterFunction: filter
+    });
+
+    this._filteredRecordArraysFor(normalizedModelName).push(array);
+
+    promise = promise || Promise.resolve(array);
+    promise = Promise.resolve(promise.then(() => array, null, `DS: Store#filter of ${normalizedModelName}`));
+
+    return PromiseArray.create({
+      promise
+    });
+  },
+});

--- a/tests/helpers/async.js
+++ b/tests/helpers/async.js
@@ -1,0 +1,38 @@
+import { all, resolve } from 'rsvp';
+import { run } from '@ember/runloop';
+
+export function wait(callback, timeout) {
+  let done = this.async();
+
+  let timer = setTimeout(() => {
+    this.ok(false, "Timeout was reached");
+    done();
+  }, timeout || 200);
+
+  return function() {
+    window.clearTimeout(timer);
+
+    let args = arguments;
+    let result;
+    try {
+      result = run(() => callback.apply(this, args));
+    } finally {
+      done();
+    }
+    return result;
+  };
+}
+
+export function asyncEqual(a, b, message) {
+  return all([
+    resolve(a),
+    resolve(b)
+  ]).then(this.wait((array) => {
+    this.push(array[0] === array[1], array[0], array[1], message);
+  }));
+}
+
+export function invokeAsync(callback, timeout = 1) {
+  setTimeout(this.wait(callback, timeout + 100), timeout);
+}
+

--- a/tests/helpers/custom-adapter.js
+++ b/tests/helpers/custom-adapter.js
@@ -1,0 +1,12 @@
+import { run } from '@ember/runloop';
+import DS from 'ember-data';
+
+export default function(env, adapterDefinition) {
+  let adapter = adapterDefinition;
+  if (!DS.Adapter.detect(adapterDefinition)) {
+    adapter = DS.Adapter.extend(adapterDefinition);
+  }
+  let store = env.store;
+  env.registry.register('adapter:-custom', adapter);
+  run(() => store.set('adapter', '-custom'));
+}

--- a/tests/helpers/owner.js
+++ b/tests/helpers/owner.js
@@ -1,0 +1,12 @@
+import EmberObject from '@ember/object';
+import Ember from 'ember';
+
+let Owner;
+
+if (Ember._RegistryProxyMixin && Ember._ContainerProxyMixin) {
+  Owner = EmberObject.extend(Ember._RegistryProxyMixin, Ember._ContainerProxyMixin);
+} else {
+  Owner = EmberObject.extend();
+}
+
+export default Owner;

--- a/tests/helpers/store.js
+++ b/tests/helpers/store.js
@@ -1,0 +1,92 @@
+import FilterMixin from 'ember-data-filter/mixins/filter';
+import { dasherize } from '@ember/string';
+import Ember from 'ember';
+import DS from 'ember-data';
+import Owner from './owner';
+
+export default function setupStore(options) {
+  let container, registry, owner;
+  let env = {};
+  options = options || {};
+
+  if (Ember.Registry) {
+    registry = env.registry = new Ember.Registry();
+    owner = Owner.create({
+      __registry__: registry
+    });
+    container = env.container = registry.container({
+      owner: owner
+    });
+    owner.__container__ = container;
+  } else {
+    container = env.container = new Ember.Container();
+    registry = env.registry = container;
+  }
+
+  env.replaceContainerNormalize = function replaceContainerNormalize(fn) {
+    if (env.registry) {
+      env.registry.normalize = fn;
+    } else {
+      env.container.normalize = fn;
+    }
+  };
+
+  let adapter = env.adapter = (options.adapter || '-default');
+  delete options.adapter;
+
+  if (typeof adapter !== 'string') {
+    env.registry.register('adapter:-ember-data-test-custom', adapter);
+    adapter = '-ember-data-test-custom';
+  }
+
+  for (let prop in options) {
+    registry.register('model:' + dasherize(prop), options[prop]);
+  }
+
+  registry.register('service:store', DS.Store.extend(FilterMixin, {
+    adapter: adapter
+  }));
+
+  registry.optionsForType('serializer', { singleton: false });
+  registry.optionsForType('adapter', { singleton: false });
+  registry.register('adapter:-default', DS.Adapter);
+
+  registry.register('serializer:-default', DS.JSONAPISerializer);
+  registry.register('serializer:-json', DS.JSONSerializer);
+  registry.register('serializer:-rest', DS.RESTSerializer);
+
+  registry.register('adapter:-rest', DS.RESTAdapter);
+  registry.register('adapter:-json-api', DS.JSONAPIAdapter);
+
+  registry.injection('serializer', 'store', 'service:store');
+
+  env.store = container.lookup('service:store');
+  env.restSerializer = container.lookup('serializer:-rest');
+  env.restSerializer.store = env.store;
+  env.serializer = env.store.serializerFor('-default');
+  env.serializer.store = env.store;
+  // lazily create the adapter method because some tets depend on
+  // modifiying the adapter in the container after setupStore is
+  // called
+  Object.defineProperty(env, 'adapter', {
+    get() {
+      if (!this._adapter) {
+        this._adapter = this.store.adapterFor('application');
+      }
+      return this._adapter;
+    },
+    set(adapter) {
+      this._adapter = adapter;
+    },
+    enumerable: true,
+    configurable: true
+  });
+
+  return env;
+}
+
+export { setupStore };
+
+export function createStore(options) {
+  return setupStore(options).store;
+}

--- a/tests/integration/filter-test.js
+++ b/tests/integration/filter-test.js
@@ -1,0 +1,937 @@
+import { hash, all } from 'rsvp';
+import { set, get, computed } from '@ember/object';
+import { run } from '@ember/runloop';
+import setupStore from 'dummy/tests/helpers/store';
+import { module, test } from 'qunit';
+import DS from 'ember-data';
+import customAdapter from 'dummy/tests/helpers/custom-adapter';
+import hasEmberVersion from 'ember-test-helpers/has-ember-version';
+import {
+  addObserver,
+  removeObserver
+} from '@ember/object/observers';
+
+let store, env, data, recordArray;
+
+const {
+  attr,
+  belongsTo,
+  Model,
+  Adapter
+} = DS;
+
+const Person = Model.extend({
+  name: attr('string'),
+  bestFriend: belongsTo('person', { inverse: null, async: false }),
+  upperName: computed('name', function() {
+    return this.get('name').toUpperCase();
+  }).readOnly()
+});
+
+module('integration/filter - Model updating', {
+  beforeEach() {
+    data = [
+      {
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Scumbag Dale'
+        },
+        relationships: {
+          bestFriend: {
+            data: {
+              id: '2',
+              type: 'person'
+            }
+          }
+        }
+      },
+      {
+        id: '2',
+        type: 'person',
+        attributes: {
+          name: 'Scumbag Katz'
+        }
+      },
+      {
+        id: '3',
+        type: 'person',
+        attributes: {
+          name: 'Scumbag Bryn'
+        }
+      }
+    ];
+
+    env = setupStore({ person: Person });
+    store = env.store;
+  },
+
+  afterEach() {
+    edited = null;
+    data = null;
+
+    run(store, 'destroy');
+  }
+});
+
+function tapFn(fn, callback) {
+  const old_fn = fn;
+
+  function new_fn() {
+    let result = old_fn.apply(this, arguments);
+    if (callback) {
+      callback.apply(fn, arguments);
+    }
+    new_fn.summary.called.push(arguments);
+    return result;
+  }
+  new_fn.summary = { called: [] };
+
+  return new_fn;
+}
+
+test('when a Model updates its relationships, its changes affect its filtered Array membership', function(assert) {
+  run(() => store.push({ data }));
+
+  let people = run(() => {
+    return store.filter('person', person => {
+      if (person.get('bestFriend') && person.get('bestFriend.name').match(/Katz$/)) {
+        return true;
+      }
+    });
+  });
+
+  run(() => assert.equal(get(people, 'length'), 1, 'precond - one item is in the RecordArray'));
+
+  let person = people.objectAt(0);
+
+  assert.equal(get(person, 'name'), 'Scumbag Dale', 'precond - the item is correct');
+
+  run(() => set(person, 'bestFriend', null));
+
+  assert.equal(get(people, 'length'), 0, 'there are now 0 items');
+
+  let erik = store.peekRecord('person', 3);
+  let yehuda = store.peekRecord('person', 2);
+
+  run(() => erik.set('bestFriend', yehuda));
+
+  person = people.objectAt(0);
+  assert.equal(get(people, 'length'), 1, 'there is now 1 item');
+  assert.equal(get(person, 'name'), 'Scumbag Bryn', 'precond - the item is correct');
+});
+
+test('a record array can have a filter on it', function(assert) {
+  run(() => store.push({ data }));
+
+  let recordArray = run(() => {
+    return store.filter('person', hash => {
+      if (hash.get('name').match(/Scumbag [KD]/)) {
+        return true;
+      }
+    });
+  });
+
+  assert.equal(get(recordArray, 'length'), 2, 'The Record Array should have the filtered objects on it');
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '4',
+        type: 'person',
+        attributes: {
+          name: 'Scumbag Koz'
+        }
+      }]
+    });
+  });
+
+  assert.equal(get(recordArray, 'length'), 3, 'The Record Array should be updated as new items are added to the store');
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Scumbag Tom'
+        }
+      }]
+    });
+  });
+
+  assert.equal(get(recordArray, 'length'), 2, 'The Record Array should be updated as existing members are updated');
+});
+
+test('a filtered record array includes created elements', function(assert) {
+  run(() => store.push({ data }));
+
+  let recordArray = run(() => {
+    return store.filter('person', hash => {
+      if (hash.get('name').match(/Scumbag [KD]/)) {
+        return true;
+      }
+    });
+  });
+
+  assert.equal(get(recordArray, 'length'), 2, 'precond - The Record Array should have the filtered objects on it');
+
+  run(() => store.createRecord('person', { name: 'Scumbag Koz' }));
+
+  assert.equal(get(recordArray, 'length'), 3, 'The record array has the new object on it');
+});
+
+test('a Record Array can update its filter', function(assert) {
+  customAdapter(env, Adapter.extend({
+    deleteRecord() {},
+    shouldBackgroundReloadRecord() { return false; }
+  }));
+
+  run(() => store.push({ data }));
+
+  let dickens = run(() => {
+    let record = store.createRecord('person', { id: 4, name: 'Scumbag Dickens' });
+    record.deleteRecord();
+    return record;
+  });
+
+  let asyncData = run(() => {
+    return {
+      dale: store.findRecord('person', 1),
+      katz: store.findRecord('person', 2),
+      bryn: store.findRecord('person', 3)
+    };
+  });
+
+  return store.filter('person', hash => {
+    if (hash.get('name').match(/Scumbag [KD]/)) {
+      return true;
+    }
+  }).then(recordArray => {
+
+    return hash(asyncData).then(records => {
+      assert.contains(recordArray, records.dale);
+      assert.contains(recordArray, records.katz);
+      assert.without(recordArray,  dickens);
+      assert.without(recordArray,  records.bryn);
+
+      run(() => {
+        recordArray.set('filterFunction', hash => {
+          if (hash.get('name').match(/Katz/)) {
+            return true;
+          }
+        });
+      });
+
+      assert.equal(get(recordArray, 'length'), 1, 'The Record Array should have one object on it');
+
+      run(() => {
+        store.push({
+          data: [{
+            id: '5',
+            type: 'person',
+            attributes: {
+              name: 'Other Katz'
+            }
+          }]
+        });
+      });
+
+      assert.equal(get(recordArray, 'length'), 2, 'The Record Array now has the new object matching the filter');
+
+      run(() => {
+        store.push({
+          data: [{
+            id: '6',
+            type: 'person',
+            attributes: {
+              name: 'Scumbag Demon'
+            }
+          }]
+        });
+      });
+
+      assert.equal(get(recordArray, 'length'), 2, 'The Record Array doesn\'t have objects matching the old filter');
+    });
+  });
+});
+
+test('it is possible to filter by computed properties', function(assert) {
+  customAdapter(env, Adapter.extend({
+    shouldBackgroundReloadRecord: () => false
+  }));
+
+  let filter = run(() => {
+    return store.filter('person', person => person.get('upperName') === 'TOM DALE');
+  });
+
+  assert.equal(filter.get('length'), 0, 'precond - the filter starts empty');
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Tom Dale'
+        }
+      }]
+    });
+  });
+
+  assert.equal(filter.get('length'), 1, 'the filter now has a record in it');
+
+  return store.findRecord('person', 1).then(person => {
+    run(() => {
+      person.set('name', 'Yehuda Katz');
+    });
+
+    assert.equal(filter.get('length'), 0, 'the filter is empty again');
+  });
+});
+
+test('a filter created after a record is already loaded works', function(assert) {
+  customAdapter(env, Adapter.extend({
+    shouldBackgroundReloadRecord() { return false; }
+  }));
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Tom Dale'
+        }
+      }]
+    });
+  });
+
+  let filter = run(() => {
+    return store.filter('person', person => person.get('upperName') === 'TOM DALE');
+  });
+
+  assert.equal(filter.get('length'), 1, 'the filter now has a record in it');
+
+  return store.findRecord('person', 1).then(person => {
+    assert.equal(filter.objectAt(0), person);
+  });
+});
+
+test('filter with query persists query on the resulting filteredRecordArray', function(assert) {
+  customAdapter(env, Adapter.extend({
+    query(store, type, id) {
+      return {
+        data: [
+          {
+            id: id,
+            type: 'person',
+            attributes: {
+              name: 'Tom Dale'
+            }
+          }
+        ]
+      };
+    }
+  }));
+
+  let filter = run(() => {
+    return store.filter('person', { foo: 1 }, () => true);
+  });
+
+  return run(() => {
+    return filter.then(array => {
+      assert.deepEqual(get(array, 'query'), { foo: 1 }, 'has expected query');
+    });
+  });
+});
+
+test('it is possible to filter by state flags', function(assert) {
+  customAdapter(env, Adapter.extend({
+    findRecord(store, type, id) {
+      return {
+        data: {
+          id,
+          type: 'person',
+          attributes: {
+            name: 'Tom Dale'
+          }
+        }
+      };
+    }
+  }));
+
+  let filter = run(() => {
+    return store.filter('person', person => person.get('isLoaded'));
+  });
+
+  assert.equal(filter.get('length'), 0, 'precond - there are no records yet');
+
+  let person = run(() => {
+    let person = store.findRecord('person', 1);
+
+    // run will block `find` from being synchronously
+    // resolved in test mode
+
+    assert.equal(filter.get('length'), 0, 'the unloaded record isn\'t in the filter');
+    return person;
+  });
+
+  return person.then(person => {
+    assert.equal(filter.get('length'), 1, 'the now-loaded record is in the filter');
+    assert.equal(filter.objectAt(0), person);
+  });
+});
+
+test('it is possible to filter loaded records by dirtiness', function(assert) {
+  customAdapter(env, Adapter.extend({
+    updateRecord(type, model, snapshot) {
+      return { data: { id: snapshot.id, type: model.modelName } };
+    },
+    shouldBackgroundReloadRecord() {
+      return false;
+    }
+  }));
+
+  let filter = store.filter('person', person => !person.get('hasDirtyAttributes'));
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Tom Dale'
+        }
+      }]
+    });
+  });
+
+  return store.findRecord('person', 1).then(person => {
+    assert.equal(filter.get('length'), 1, 'the clean record is in the filter');
+
+    // Force synchronous update of the filter, even though
+    // we're already inside a run loop
+    run(() => person.set('name', 'Yehuda Katz'));
+
+    assert.equal(filter.get('length'), 0, 'the now-dirty record is not in the filter');
+
+    return person.save();
+  }).then(() => {
+    assert.equal(filter.get('length'), 1, 'the clean record is back in the filter');
+  });
+});
+
+test('it is possible to filter created records by dirtiness', function(assert) {
+  run(() => {
+    customAdapter(env, Adapter.extend({
+      createRecord(type, model, snapshot) {
+        return {
+          data: {
+            id: snapshot.id,
+            type: model.modelName,
+            attributes: snapshot._attributes
+          }
+        }
+      },
+      shouldBackgroundReloadRecord() { return false; }
+    }));
+  });
+
+  let filter = run(() => {
+    return store.filter('person', person => !person.get('hasDirtyAttributes'));
+  });
+
+  let person = run(() => store.createRecord('person', {
+    id: 1,
+    name: 'Tom Dale'
+  }));
+
+  assert.equal(filter.get('length'), 0, 'the dirty record is not in the filter');
+
+  return run(() => {
+    return person.save().then(() => {
+      assert.equal(filter.get('length'), 1, 'the clean record is in the filter');
+    });
+  });
+});
+
+if (hasEmberVersion(3, 0)) {
+  test('when a Model updates its attributes, its changes affect its filtered Array membership', function(assert) {
+    run(() => store.push({ data }));
+
+    let recalculatedArr = 0;
+    let recalculatedLen = 0;
+    let people = run(() => store.filter('person', hash => {
+      return !!hash.get('name').match(/Katz$/);
+    }));
+
+    function observeArr() {
+      recalculatedArr++;
+    }
+    function observeLen() {
+      recalculatedLen++;
+    }
+
+    addObserver(people, '[]', observeArr);
+    addObserver(people, 'length', observeLen);
+
+    assert.equal(recalculatedArr, 0, 'precond - We have not yet recalculated membership');
+    assert.equal(recalculatedLen, 0, 'precond - We have not yet recalculated length');
+    assert.equal(get(people, 'length'), 1, 'precond - one item is in the RecordArray');
+
+    const person = people.objectAt(0);
+
+    assert.equal(get(person, 'name'), 'Scumbag Katz', 'precond - the item is correct');
+
+    run(() => set(person, 'name', 'Yehuda Katz'));
+
+    assert.equal(recalculatedArr, 1, 'We have recalculated membership once');
+    assert.equal(recalculatedLen, 0, 'We have not yet recalculated length');
+    assert.equal(get(people, 'length'), 1, 'there is still one item');
+    assert.equal(get(person, 'name'), 'Yehuda Katz', "it has the updated item");
+
+    run(() => set(person, 'name', 'Yehuda Hats'));
+
+    assert.equal(recalculatedArr, 2, 'We have recalculated twice');
+    assert.equal(recalculatedLen, 1, 'We have only recalculated length once');
+    assert.equal(get(people, 'query'), null, 'expected no query object set');
+    assert.equal(get(people, 'length'), 0, 'there are now no items');
+    removeObserver(people, '[]', observeArr);
+    removeObserver(people, 'length', observeLen);
+  });
+
+  test('a Record Array can update its filter and notify array observers', function(assert) {
+    customAdapter(env, Adapter.extend({
+      deleteRecord() {},
+      shouldBackgroundReloadRecord() { return false; }
+    }));
+
+    run(() => store.push({ data }));
+
+    let dickens;
+
+    run(() => {
+      dickens = store.createRecord('person', { id: 4, name: 'Scumbag Dickens' });
+    });
+
+    let asyncData = run(() => {
+      return [
+        store.findRecord('person', 1),
+        store.findRecord('person', 2),
+        store.findRecord('person', 3)
+      ];
+    });
+
+    let filterPromiseProxy = run(() => store.filter(
+      'person',
+      hash => !!hash.get('name').match(/Scumbag [KD]/)
+    ));
+
+    let recalculatedArr = 0;
+    let recalculatedLen = 0;
+
+    function observeArr() { recalculatedArr++; }
+    function observeLen() { recalculatedLen++; }
+
+    addObserver(filterPromiseProxy, '[]', observeArr);
+    addObserver(filterPromiseProxy, 'length', observeLen);
+
+    return filterPromiseProxy.then((people) => {
+
+      // initial state
+      assert.equal(people.get('length'), 3, 'two clean and one new record in the array');
+      assert.equal(recalculatedArr, 0, 'No change notifications yet');
+      assert.equal(recalculatedLen, 0, 'No change notifications yet');
+
+      // watch deletions
+      run(() => { dickens.unloadRecord(); });
+
+      assert.equal(people.get('length'), 2, 'two clean records in the array');
+
+      // TODO make ember-data less noisy
+      assert.equal(recalculatedArr, 2, '2 change notifications for 1 deletion');
+      assert.equal(recalculatedLen, 2, '2 change notifications for 1 deletion');
+
+      // change up the filter
+      run(() => {
+        people.set('filterFunction', hash => {
+          if (hash.get('name').match(/Katz/)) {
+            return true;
+          }
+        });
+      });
+
+      assert.equal(people.get('length'), 1, 'Only one Katz in the array');
+      assert.equal(recalculatedArr, 3, '1 more change notifications for filter swap');
+      assert.equal(recalculatedLen, 3, '1 more change notifications for filter swap');
+
+      return all(asyncData).then(() => {
+        assert.equal(people.get('length'), 1, 'Still only one Katz in the array');
+        assert.equal(recalculatedArr, 3, 'no values updated so filters were not rerun');
+        assert.equal(recalculatedLen, 3, 'no values updated so filters were not rerun');
+
+        run(() => {
+          store.push({
+            data: {
+              id: '5',
+              type: 'person',
+              attributes: {
+                name: 'Other Katz'
+              }
+            }
+          });
+        });
+
+        assert.equal(people.get('length'), 2, 'We added a Katz to the array');
+        // TODO make ember-data less noisy, this is likely due to observer causing two
+        //   recalculations
+        assert.equal(recalculatedArr, 5, '1 more change notifications for add');
+        assert.equal(recalculatedLen, 5, '1 more change notifications for add');
+        assert.deepEqual(people.map(p => p.get('name')), ['Scumbag Katz', 'Other Katz'], 'We have the right people');
+
+        run(() => {
+          store.push({
+            data: {
+              id: '6',
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Demon'
+              }
+            }
+          });
+        });
+
+        assert.equal(people.get('length'), 2, 'We had no change to the array');
+        // TODO make ember-data less noisy, this is likely due to observer causing two
+        //   recalculations
+        assert.equal(recalculatedArr, 7, '1 more change notifications for add-caused filter-rerun');
+        assert.equal(recalculatedLen, 5, 'no more change notifications, as length did not change');
+
+        removeObserver(filterPromiseProxy, '[]', observeArr);
+        removeObserver(filterPromiseProxy, 'length', observeLen);
+      });
+    });
+  });
+}
+
+// SERVER SIDE TESTS
+let edited;
+
+function clientEdits(ids) {
+  edited = [];
+
+  ids.forEach(id => {
+    // wrap in an run to guarantee coalescence of the
+    // iterated `set` calls and promise resolution.
+    run(() => {
+      store.findRecord('person', id).then(person => {
+        edited.push(person);
+        person.set('name', 'Client-side ' + id );
+      });
+    });
+  });
+}
+
+function clientCreates(names) {
+  // wrap in an run to guarantee coalescence of the
+  // iterated `set` calls.
+  run(() => {
+    edited = names.map(name => store.createRecord('person', { name: 'Client-side ' + name }));
+  });
+}
+
+function serverResponds() {
+  edited.forEach(person => run(person, 'save'));
+}
+
+function setup(assert, serverCallbacks) {
+  customAdapter(env, Adapter.extend(serverCallbacks));
+
+  run(() => {
+    store.push({ data });
+
+    recordArray = store.filter('person', hash => {
+      if (hash.get('name').match(/Scumbag/)) {
+        return true;
+      }
+    });
+  });
+
+  assert.equal(get(recordArray, 'length'), 3, 'The filter function should work');
+}
+
+test('a Record Array can update its filter after server-side updates one record', function(assert) {
+  setup(assert, {
+    updateRecord() {
+      return {
+        data: {
+          id: 1,
+          type: 'person',
+          attributes: {
+            name: 'Scumbag Server-side Dale'
+          }
+        }
+      };
+    },
+    shouldBackgroundReloadRecord() { return false; }
+  });
+
+  clientEdits([1]);
+  assert.equal(get(recordArray, 'length'), 2, 'The record array updates when the client changes records');
+
+  serverResponds();
+  assert.equal(get(recordArray, 'length'), 3, 'The record array updates when the server changes one record');
+});
+
+test('a Record Array can update its filter after server-side updates multiple records', function(assert) {
+  setup(assert, {
+    updateRecord(store, type, snapshot) {
+      switch (snapshot.id) {
+        case '1':
+          return {
+            data: {
+              id: 1,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side Dale'
+              }
+            }
+          };
+        case '2':
+          return {
+            data: {
+              id: 2,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side Katz'
+              }
+            }
+          };
+      }
+    },
+    shouldBackgroundReloadRecord() { return false; }
+  });
+
+  clientEdits([1, 2]);
+  assert.equal(get(recordArray, 'length'), 1, 'The record array updates when the client changes records');
+
+  serverResponds();
+  assert.equal(get(recordArray, 'length'), 3, 'The record array updates when the server changes multiple records');
+});
+
+test('a Record Array can update its filter after server-side creates one record', function(assert) {
+  setup(assert, {
+    createRecord() {
+      return {
+        data: {
+          id: 4,
+          type: 'person',
+          attributes: {
+            name: 'Scumbag Server-side Tim'
+          }
+        }
+      };
+    }
+  });
+
+  clientCreates(['Tim']);
+  assert.equal(get(recordArray, 'length'), 3, 'The record array does not include non-matching records');
+
+  serverResponds();
+  assert.equal(get(recordArray, 'length'), 4, 'The record array updates when the server creates a record');
+});
+
+test('a Record Array can update its filter after server-side creates multiple records', function(assert) {
+  setup(assert, {
+    createRecord(store, type, snapshot) {
+      switch (snapshot.attr('name')) {
+        case 'Client-side Mike':
+          return {
+            data: {
+              id: 4,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side Mike'
+              }
+            }
+          };
+        case 'Client-side David':
+          return {
+            data: {
+              id: 5,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side David'
+              }
+            }
+          };
+      }
+    }
+  });
+
+  clientCreates(['Mike', 'David']);
+  assert.equal(get(recordArray, 'length'), 3, 'The record array does not include non-matching records');
+
+  serverResponds();
+  assert.equal(get(recordArray, 'length'), 5, 'The record array updates when the server creates multiple records');
+});
+
+test('a Record Array can update its filter after server-side creates multiple records', function(assert) {
+  setup(assert, {
+    createRecord(store, type, snapshot) {
+      switch (snapshot.attr('name')) {
+        case 'Client-side Mike':
+          return {
+            data: {
+              id: 4,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side Mike'
+              }
+            }
+          };
+        case 'Client-side David':
+          return {
+            data: {
+              id: 5,
+              type: 'person',
+              attributes: {
+                name: 'Scumbag Server-side David'
+              }
+            }
+          };
+      }
+    }
+  });
+
+  clientCreates(['Mike', 'David']);
+  assert.equal(get(recordArray, 'length'), 3, 'The record array does not include non-matching records');
+
+  serverResponds();
+  assert.equal(get(recordArray, 'length'), 5, 'The record array updates when the server creates multiple records');
+});
+
+test('destroying filteredRecordArray unregisters models from being filtered', function(assert) {
+  const filterFn = tapFn(() => true);
+
+  let recalculatedArr = 0;
+  let recalculatedLen = 0;
+
+  function observeArr() {
+    recalculatedArr++;
+  }
+  function observeLen() {
+    recalculatedLen++;
+  }
+
+  customAdapter(env, Adapter.extend({
+    shouldBackgroundReloadRecord() { return false; }
+  }));
+
+  run(() => {
+    store.push({
+      data: [{
+        id: '1',
+        type: 'person',
+        attributes: {
+          name: 'Tom Dale'
+        }
+      }]
+    });
+  });
+
+  const people = run(() => store.filter('person', filterFn));
+
+  addObserver(people, '[]', observeArr);
+  addObserver(people, 'length', observeLen);
+
+  assert.equal(filterFn.summary.called.length, 1);
+
+  run(() => people.then(array => array.destroy()));
+
+  clientEdits([1]);
+  run(() => {
+    store.push({
+      data: {
+        id: '2',
+        type: 'person',
+        attributes: {
+          name: '@runspired'
+        }
+      }
+    });
+  });
+
+  assert.equal(filterFn.summary.called.length, 1, 'expected the filter function not being called anymore');
+
+  removeObserver(people, '[]', observeArr);
+  removeObserver(people, 'length', observeLen);
+  assert.equal(recalculatedArr, 0, 'We did not update content');
+  assert.equal(recalculatedLen, 0, 'We did not update length');
+});
+
+test("store.filter should pass adapterOptions to adapter.query", function(assert) {
+  assert.expect(2);
+
+  env.adapter.query = function(store, type, query, array, options) {
+    assert.ok(!('adapterOptions' in query));
+    assert.deepEqual(options.adapterOptions, { query: { embed: true } });
+    return { data: [] };
+  };
+
+  return run(() => {
+    return store.filter('person', {}, () => {}, { adapterOptions: { query: { embed: true } } });
+  });
+});
+
+test('unloading filtered records', function(assert) {
+  function push() {
+    run(() => {
+      store.push({
+        data: [
+          {
+            type: 'person',
+            id: '1',
+            attributes: {
+              name: 'Scumbag John'
+            }
+          },
+          {
+            type: 'person',
+            id: '2',
+            attributes: {
+              name: 'Scumbag Joe'
+            }
+          }
+        ]
+      });
+    });
+  }
+
+  let people = run(() => {
+    return store.filter('person', hash => {
+      if (hash.get('name').match(/Scumbag/)) {
+        return true;
+      }
+    });
+  });
+
+  assert.equal(get(people, 'length'), 0, 'precond - no items in the RecordArray');
+
+  push();
+
+  assert.equal(get(people, 'length'), 2, 'precond - two items in the RecordArray');
+
+  run(() => {
+    people.objectAt(0).unloadRecord();
+
+    assert.equal(get(people, 'length'), 2, 'Unload does not complete until the end of the loop');
+    assert.equal(get(people.objectAt(0), 'name'), 'Scumbag John', 'John is still the first object until the end of the loop');
+  });
+
+  assert.equal(get(people, 'length'), 1, 'Unloaded record removed from the array');
+  assert.equal(get(people.objectAt(0), 'name'), 'Scumbag Joe', 'Joe shifted down after the unload');
+});
+
+

--- a/tests/integration/teardown-test.js
+++ b/tests/integration/teardown-test.js
@@ -1,0 +1,48 @@
+import { run } from '@ember/runloop';
+import setupStore from 'dummy/tests/helpers/store';
+import { module, test } from 'qunit';
+import DS from 'ember-data';
+
+const Person = DS.Model.extend({
+  name: DS.attr('string'),
+});
+
+module("integration/store - destroy", {
+  beforeEach() {
+    this.store = setupStore({
+      person: Person
+    }).store;
+  },
+});
+
+function tap(obj, methodName, callback) {
+  let old = obj[methodName];
+
+  let summary = { called: [] };
+
+  obj[methodName] = function() {
+    let result = old.apply(obj, arguments);
+    if (callback) {
+      callback.apply(obj, arguments);
+    }
+    summary.called.push(arguments);
+    return result;
+  };
+
+  return summary;
+}
+
+test("destroying the store correctly cleans up filters", function(assert) {
+  let store = this.store;
+  let filterdPeople = run(() => store.filter('person', () => true));
+  let filter = filterdPeople.get('content');
+  let filterdPeopleWillDestroy = tap(filter, 'willDestroy');
+
+  assert.equal(filterdPeopleWillDestroy.called.length, 0, 'expected filterdPeople.willDestroy to not have been called');
+
+  run(store, 'destroy');
+
+  assert.equal(filter.isDestroying, true, 'We marked the filter for destroy');
+  assert.equal(filter.isDestroyed, true, 'We destroyed the filter');
+  assert.equal(filterdPeopleWillDestroy.called.length, 1, 'expected filterdPeople.willDestroy to have been called once');
+});

--- a/tests/test-helper.js
+++ b/tests/test-helper.js
@@ -2,7 +2,65 @@ import Application from '../app';
 import config from '../config/environment';
 import { setApplication } from '@ember/test-helpers';
 import { start } from 'ember-qunit';
+import RSVP from 'rsvp';
+import QUnit from 'qunit';
+import DS from 'ember-data';
+import {
+  wait,
+  asyncEqual,
+  invokeAsync
+} from 'dummy/tests/helpers/async';
+
+const { assert } = QUnit;
+const transforms = {
+  boolean: DS.BooleanTransform.create(),
+  date:    DS.DateTransform.create(),
+  number:  DS.NumberTransform.create(),
+  string:  DS.StringTransform.create()
+};
+
+QUnit.begin(() => {
+  RSVP.configure('onerror', reason => {
+    // only print error messages if they're exceptions;
+    // otherwise, let a future turn of the event loop
+    // handle the error.
+    if (reason && reason instanceof Error) {
+      throw reason;
+    }
+  });
+
+  // Prevent all tests involving serialization to require a container
+  DS.JSONSerializer.reopen({
+    transformFor(attributeType) {
+      return this._super(attributeType, true) || transforms[attributeType];
+    }
+  });
+
+});
+
+assert.wait = wait;
+assert.asyncEqual = asyncEqual;
+assert.invokeAsync = invokeAsync;
+assert.assertClean = function(promise) {
+  return promise.then(this.wait(record => {
+    this.equal(record.get('hasDirtyAttributes'), false, 'The record is now clean');
+    return record;
+  }));
+};
+
+assert.contains = function(array, item) {
+  this.ok(array.indexOf(item) !== -1, `array contains ${item}`);
+};
+
+assert.without = function(array, item)  {
+  this.ok(array.indexOf(item) === -1, `array doesn't contain ${item}`);
+};
+
+QUnit.config.testTimeout = 2000;
+QUnit.config.urlConfig.push({
+  id: 'enableoptionalfeatures',
+  label: 'Enable Opt Features'
+});
 
 setApplication(Application.create(config.APP));
-
-start();
+start({ setupTestIsolationValidation: true });

--- a/tests/unit/filter-test.js
+++ b/tests/unit/filter-test.js
@@ -1,0 +1,12 @@
+import { module, test } from 'qunit';
+import { FilteredRecordArray } from 'ember-data-filter/mixins/filter';
+
+module('unit/record-arrays/filtered-record-array - DS.FilteredRecordArray');
+
+test('#replace() throws error', function(assert) {
+  let recordArray = FilteredRecordArray.create({ modelName: 'recordType' });
+
+  assert.throws(() => {
+    recordArray.replace();
+  }, Error('The result of a client-side filter (on recordType) is immutable.'), 'throws error');
+});


### PR DESCRIPTION
Allows us to eliminate all `filter` implementation code from `ember-data` itself, and deprecates the use of `store.filter`.